### PR TITLE
Exclude `renovate.json` from package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["uutils developers"]
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.70"
+exclude = ["/renovate.json"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
The renovate.json file shouldn't be included in the package as it's only used for development.